### PR TITLE
Patch nested modules

### DIFF
--- a/src/AzureFunctions.PowerShell.Durable.SDK.psd1
+++ b/src/AzureFunctions.PowerShell.Durable.SDK.psd1
@@ -58,7 +58,7 @@
     # FormatsToProcess = @()
     
     # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-    NestedModules = @('.\out\DurableSDK.dll', 'DurableSDK.psm1')
+    NestedModules = @('.\AzureFunctions.PowerShell.Durable.SDK.dll')
     
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @(


### PR DESCRIPTION
Before releasing the alpha package, we need to ensure the files listed in `NestedModules` can be found. Since the package is now named `AzureFunctions.PowerShell.Durable.SDK`, the value of `NestedModules` has been updated accordingly.