### PR TITLE
Patch terminate test

### DIFF
--- a/src/AzureFunctions.PowerShell.Durable.SDK.psm1
+++ b/src/AzureFunctions.PowerShell.Durable.SDK.psm1
@@ -3,6 +3,8 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
+using namespace System.Net
+
 # Set aliases for cmdlets to export
 # Set-Alias -Name Wait-ActivityFunction -Value Wait-DurableTask
 # Set-Alias -Name Invoke-ActivityFunction -Value Invoke-DurableActivity
@@ -159,7 +161,7 @@ function Stop-DurableOrchestrationE {
 
     $requestUrl = "$($DurableClient.BaseUrl)/instances/$InstanceId/terminate?reason=$([System.Web.HttpUtility]::UrlEncode($Reason))"
 
-    Invoke-RestMethod -Uri $requestUrl
+    Invoke-RestMethod -Uri $requestUrl -Method 'POST'
 }
 
 function IsValidUrl([uri]$Url) {

--- a/src/DurableEngine/OrchestrationInvoker.cs
+++ b/src/DurableEngine/OrchestrationInvoker.cs
@@ -56,7 +56,7 @@ namespace DurableEngine
             // DF API.
             // Similarly, the user code thread / PS orchestrator will block its own thread until this function is done `await`'ing
             // the requested APIs.
-            Func<TaskOrchestrationContext, int, Task<object>> apiInvokerFunction = async (TaskOrchestrationContext DTFxContext, int _) =>
+            Func<TaskOrchestrationContext, object, Task<object>> apiInvokerFunction = async (TaskOrchestrationContext DTFxContext, object _) =>
             {
                 context.DTFxContext = DTFxContext;
 
@@ -126,7 +126,7 @@ namespace DurableEngine
         /// </summary>
         /// <param name="apiInvokerFunction">A C# Function that calls DF APIs.</param>
         /// <returns>An orchestrator executor implementing DF replay.</returns>
-        private TaskOrchestrationExecutor CreateTaskOrchestrationExecutor(Func<TaskOrchestrationContext, int, Task<object>> apiInvokerFunction)
+        private TaskOrchestrationExecutor CreateTaskOrchestrationExecutor(Func<TaskOrchestrationContext, object, Task<object>> apiInvokerFunction)
         {
             // Construct the OrchestratorState object. The key here is to correctly distinguish new events from past ones.
             OrchestratorState state = new OrchestratorState();

--- a/test/E2E/durableApp/DurableAppHttpStartTerminating/run.ps1
+++ b/test/E2E/durableApp/DurableAppHttpStartTerminating/run.ps1
@@ -5,7 +5,7 @@ $FunctionName = $Request.Params.FunctionName ?? 'DurablePatternsOrchestrator'
 $InstanceId = Start-DurableOrchestrationExternal -FunctionName $FunctionName -InputObject 'Hello'
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
-Stop-DurableOrchestrationExternal -InstanceId $InstanceId -Reason 'Terminated intentionally'
+Stop-DurableOrchestrationE -InstanceId $InstanceId -Reason 'Terminated intentionally'
 
 $Response = New-DurableOrchestrationCheckStatusResponseExternal -Request $Request -InstanceId $InstanceId
 Push-OutputBinding -Name Response -Value $Response


### PR DESCRIPTION
This PR allows the "terminate test" to pass.
3 changes were needed:
1) Import `System.Net` in the `.psm1` script so that `[HttpStatusCode]` may be recognized as a type
2) Have the Stop-Orchestration CmdLet use a `POST` request instead of `GET`
3) This was the tricky one: Ensure the orchestrator can take as input any type. Previously, it had `int` hardcoded as the input type. After changing it to `object`, the orchestrator executes correctly under this test. It appears we did not explicitly test passing inputs to orchestrators using the external SDK, and so we missed this. The execution of the orchestrator was unable to start as a result. We should consider ways of detecting this case in the future, although that might require explicit support from the C#-isolated SDK as the error is thrown at that level.