### PR TITLE
Generate actions at most once

### DIFF
--- a/src/AzureFunctions.PowerShell.Durable.SDK.psm1
+++ b/src/AzureFunctions.PowerShell.Durable.SDK.psm1
@@ -15,7 +15,7 @@ Set-Alias -Name Start-NewOrchestrationE -Value Start-DurableOrchestrationExterna
 function GetDurableClientFromModulePrivateData {
     $PrivateData = $PSCmdlet.MyInvocation.MyCommand.Module.PrivateData
     if ($null -eq $PrivateData -or $null -eq $PrivateData['DurableClient']) {
-        throw "No binding of the type 'durableClient' was defined."
+        throw "Could not find `DurableClient` private data. This can occur when you have not set application setting 'ExternalDurablePowerShellSDK' to 'true' or if you're using a DurableClient CmdLet but have no DurableClient binding declared in `function.json`."
     }
     else {
         $PrivateData['DurableClient']

--- a/src/DurableEngine/Tasks/WhenAllTask.cs
+++ b/src/DurableEngine/Tasks/WhenAllTask.cs
@@ -43,7 +43,7 @@ namespace DurableEngine.Tasks
 
         internal override OrchestrationAction CreateOrchestrationAction()
         {
-            var compoundActions = Tasks.Select((task) => task.CreateOrchestrationAction()).ToArray();
+            var compoundActions = Tasks.Select((task) => task.OrchestrationAction).ToArray();
             var orchestrationAction = new WhenAllAction(compoundActions);
             return orchestrationAction;
         }

--- a/src/DurableEngine/Tasks/WhenAnyTask.cs
+++ b/src/DurableEngine/Tasks/WhenAnyTask.cs
@@ -41,7 +41,7 @@ namespace DurableEngine.Tasks
         
         internal override OrchestrationAction CreateOrchestrationAction()
         {
-            var compoundActions = Tasks.Select((task) => task.CreateOrchestrationAction()).ToArray();
+            var compoundActions = Tasks.Select((task) => task.OrchestrationAction).ToArray();
             var action = new WhenAnyAction(compoundActions);
             return action;
         }


### PR DESCRIPTION
Preamble to implementing Get-DurableTaskResult, which effectively calls await on an already scheduled DF API to get its result.
Whenever we "await" a DF API, we only want that API to generate an action once. Otherwise, a copy of the task will be scheduled