### PR TITLE
Decrease the time to send external event in E2E test

### DIFF
--- a/test/E2E/durableApp/DurableClientSendExternalEvent/run.ps1
+++ b/test/E2E/durableApp/DurableClientSendExternalEvent/run.ps1
@@ -3,7 +3,7 @@ $ErrorActionPreference = 'Stop'
 
 Write-Host "DurableClientSendExternalEvent started"
 
-$OrchestratorInputs = @{ FirstDuration = 5; SecondDuration = 30 }
+$OrchestratorInputs = @{ FirstDuration = 5; SecondDuration = 60 }
 
 $InstanceId = Start-DurableOrchestration -FunctionName "SendDurableExternalEventOrchestrator" -InputObject $OrchestratorInputs
 Write-Host "Started orchestration with ID = '$InstanceId'"


### PR DESCRIPTION
Currently, the test to send external events is a bit unreliable since the `HttpClient` times out after a default `TimeSpan` of 100 seconds. This change decreases the amount of time we wait before sending an external event to mitigate that.