### PR TITLE
Correct pipeline logging statement

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ steps:
       $isReleaseBuild = $false
       if (-not([bool]::TryParse($env:IsReleaseBuild, [ref] $isReleaseBuild)))
       {
-          throw "SimulateReleaseBuild can only be set to true or false."
+          throw "IsReleaseBuild can only be set to true or false."
       }
 
       # We only generate an SBOM for release or simulated release builds


### PR DESCRIPTION
Currently, the pipeline reports errors parsing the `SimulateReleaseBuild` variable when it is parsing the `IsReleaseBuild`. This patches the logging statement.