### PR TITLE
Deserialize DF orchestrator input

### DIFF
--- a/src/DurableEngine/Models/OrchestrationContext.cs
+++ b/src/DurableEngine/Models/OrchestrationContext.cs
@@ -23,7 +23,8 @@ namespace DurableEngine.Models
         /// Input to the orchestrator.
         /// </summary>
         [DataMember]
-        public object Input { 
+        public object Input
+        { 
             get => DTFxContext?.GetInput<object>();
         }
 

--- a/src/DurableEngine/Models/OrchestrationContext.cs
+++ b/src/DurableEngine/Models/OrchestrationContext.cs
@@ -23,7 +23,9 @@ namespace DurableEngine.Models
         /// Input to the orchestrator.
         /// </summary>
         [DataMember]
-        public object Input { get; set; }
+        public object Input { 
+            get => DTFxContext?.GetInput<object>();
+        }
 
         /// <summary>
         /// Orchestrator instanceID.

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/DurableClientTests.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/DurableClientTests.cs
@@ -89,6 +89,42 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
         }
 
         [Fact]
+        public async Task DurableSubOrchestratoWithArrayInputCompletes()
+        {
+            var initialResponse = await Utilities.GetHttpStartResponse("SubOrchestratorWithArrayInput");
+            Assert.Equal(HttpStatusCode.Accepted, initialResponse.StatusCode);
+
+            var location = initialResponse.Headers.Location;
+            Assert.NotNull(location);
+
+            await ValidateDurableWorkflowResults(
+                initialResponse,
+                validateInitialResponse: (dynamic initialStatusResponseBody) =>
+                {
+                    Assert.NotNull(initialStatusResponseBody.id);
+                    var statusQueryGetUri = (string)initialStatusResponseBody.statusQueryGetUri;
+                    Assert.Equal(location?.ToString(), statusQueryGetUri);
+                    Assert.NotNull(initialStatusResponseBody.sendEventPostUri);
+                    Assert.NotNull(initialStatusResponseBody.purgeHistoryDeleteUri);
+                    Assert.NotNull(initialStatusResponseBody.terminatePostUri);
+                    Assert.NotNull(initialStatusResponseBody.rewindPostUri);
+                },
+                validateIntermediateResponse: (dynamic intermediateStatusResponseBody) =>
+                {
+                    var runtimeStatus = (string)intermediateStatusResponseBody.runtimeStatus;
+                    Assert.True(
+                        runtimeStatus == "Running" || runtimeStatus == "Pending",
+                        $"Unexpected runtime status: {runtimeStatus}");
+                },
+                validateFinalResponse: (dynamic finalStatusResponseBody) =>
+                {
+                    Assert.Equal("Completed", (string)finalStatusResponseBody.runtimeStatus);
+                    Assert.Equal("Hello Tokyo", finalStatusResponseBody.output[0].ToString());
+                    Assert.Equal("Hello Seattle", finalStatusResponseBody.output[1].ToString());
+                });
+        }
+
+        [Fact]
         public async Task OrchestratorCanReceiveArrayFromActivity()
         {
             var initialResponse = await Utilities.GetHttpStartResponse("CanReceiveArrayOrchestrator");

--- a/test/E2E/durableApp/FanOutOnInputOrchestrator/function.json
+++ b/test/E2E/durableApp/FanOutOnInputOrchestrator/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/durableApp/FanOutOnInputOrchestrator/run.ps1
+++ b/test/E2E/durableApp/FanOutOnInputOrchestrator/run.ps1
@@ -1,0 +1,15 @@
+using namespace System.Net
+
+param($Context)
+
+$ErrorActionPreference = 'Stop'
+
+$output = @()
+# call activity in every input
+foreach ($input in $Context.Input)
+{
+    # invoke the activity function
+    $output += Invoke-DurableActivity -FunctionName "Hello" -Input $input
+}
+
+return $output

--- a/test/E2E/durableApp/FanOutOnInputOrchestrator/run.ps1
+++ b/test/E2E/durableApp/FanOutOnInputOrchestrator/run.ps1
@@ -5,7 +5,11 @@ param($Context)
 $ErrorActionPreference = 'Stop'
 
 $output = @()
-# call activity in every input
+
+# We call an activity for every element in the input list.
+# This allows us to test that array-type inputs are correctly serialized.
+# In the past, we've seen issues where arrays are received as JTokens instead of as PS lists.
+# Since we cannot iterate over JTokens, an incorrectly serialized array will result in no activities being called. Our test will then error.
 foreach ($input in $Context.Input)
 {
     # invoke the activity function

--- a/test/E2E/durableApp/SubOrchestratorWithArrayInput/function.json
+++ b/test/E2E/durableApp/SubOrchestratorWithArrayInput/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/durableApp/SubOrchestratorWithArrayInput/run.ps1
+++ b/test/E2E/durableApp/SubOrchestratorWithArrayInput/run.ps1
@@ -1,0 +1,10 @@
+using namespace System.Net
+
+param($Context)
+
+$ErrorActionPreference = 'Stop'
+
+$output = @()
+$output += Invoke-DurableSubOrchestrator -FunctionName "FanOutOnInputOrchestrator" -Input @("Tokyo", "Seattle")
+
+return $output


### PR DESCRIPTION
It appears we're not currently applying our deserialization helper to the orchestration input. The result is that simple enough inputs like strings and numbers are correctly assigned, but more complex input like arrays are currently still represented as a JToken. The fix simple, to access the input through the C# isolated `GetInput` API.