### PR TITLE
Remove redundant and error-prone call to `.Reset()` in our AutoResetEvents

### DIFF
--- a/src/DurableEngine/OrchestrationInvoker.cs
+++ b/src/DurableEngine/OrchestrationInvoker.cs
@@ -69,6 +69,7 @@ namespace DurableEngine
 
                 // Start user-code thread, which contains the "actual" PS orchestrator
                 var outputBuffer = new PSDataCollection<object>();
+
                 var asyncResult = powerShellServices.BeginInvoke(outputBuffer);
                 var orchestratorReturnedHandle = asyncResult.AsyncWaitHandle;
 
@@ -109,6 +110,7 @@ namespace DurableEngine
                         await task.GetDTFxTask();
                     } // Exceptions are ignored at this point, they will be re-surfaced by the PS code if left unhandled.
                     catch { }
+                    context.SharedMemory.userCodeThreadTurn.Set();
                 }
             };
 

--- a/src/DurableEngine/OrchestrationInvoker.cs
+++ b/src/DurableEngine/OrchestrationInvoker.cs
@@ -69,7 +69,6 @@ namespace DurableEngine
 
                 // Start user-code thread, which contains the "actual" PS orchestrator
                 var outputBuffer = new PSDataCollection<object>();
-
                 var asyncResult = powerShellServices.BeginInvoke(outputBuffer);
                 var orchestratorReturnedHandle = asyncResult.AsyncWaitHandle;
 

--- a/src/DurableEngine/SharedMemory.cs
+++ b/src/DurableEngine/SharedMemory.cs
@@ -38,11 +38,11 @@ namespace DurableEngine
         /// </summary>
         public void YieldToInvokerThread()
         {
+            // Get user-code thread ready to block.
+            userCodeThreadTurn.Reset();
+
             // Wake invoker thread.
             invokerThreadTurn.Set();
-
-            // Block user-code thread.
-            userCodeThreadTurn.Reset();
             userCodeThreadTurn.WaitOne();
         }
 
@@ -54,11 +54,11 @@ namespace DurableEngine
         /// <returns>True if the user-code thread completed, False if it requests an API to be awaited.</returns>
         public bool YieldToUserCodeThread(WaitHandle completionHandle)
         {
-            // Wake user-code thread
-            userCodeThreadTurn.Set();
-
             // Get invoker thread ready to block
             invokerThreadTurn.Reset();
+
+            // Wake user-code thread
+            userCodeThreadTurn.Set();
 
             // Wake up when either the user-code returns, or when we're yielded-to for `await`'ing.
             var index = WaitHandle.WaitAny(new[] { completionHandle, invokerThreadTurn });

--- a/src/DurableEngine/SharedMemory.cs
+++ b/src/DurableEngine/SharedMemory.cs
@@ -38,9 +38,6 @@ namespace DurableEngine
         /// </summary>
         public void YieldToInvokerThread()
         {
-            // Get user-code thread ready to block.
-            userCodeThreadTurn.Reset();
-
             // Wake invoker thread.
             invokerThreadTurn.Set();
             userCodeThreadTurn.WaitOne();
@@ -54,9 +51,6 @@ namespace DurableEngine
         /// <returns>True if the user-code thread completed, False if it requests an API to be awaited.</returns>
         public bool YieldToUserCodeThread(WaitHandle completionHandle)
         {
-            // Get invoker thread ready to block
-            invokerThreadTurn.Reset();
-
             // Wake user-code thread
             userCodeThreadTurn.Set();
 

--- a/src/DurableEngine/SharedMemory.cs
+++ b/src/DurableEngine/SharedMemory.cs
@@ -5,6 +5,7 @@
 
 namespace DurableEngine
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -51,23 +52,11 @@ namespace DurableEngine
         /// <returns>True if the user-code thread completed, False if it requests an API to be awaited.</returns>
         public bool YieldToUserCodeThread(WaitHandle completionHandle)
         {
-            // Wake user-code thread
-            userCodeThreadTurn.Set();
 
             // Wake up when either the user-code returns, or when we're yielded-to for `await`'ing.
             var index = WaitHandle.WaitAny(new[] { completionHandle, invokerThreadTurn });
             var shouldStop = index == 0;
             return shouldStop;
-        }
-
-        /// <summary>
-        /// Blocks user code thread if the orchestrator-invoker thread is currently running.
-        /// This guarantees that the user-code thread and the orchestration-invoker thread run one
-        /// at a time after this point.
-        /// </summary>
-        public void GuaranteeUserCodeTurn()
-        {
-            userCodeThreadTurn.WaitOne();
         }
     }
 }

--- a/src/DurableEngine/SharedMemory.cs
+++ b/src/DurableEngine/SharedMemory.cs
@@ -5,7 +5,6 @@
 
 namespace DurableEngine
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/DurableEngine/SharedMemory.cs
+++ b/src/DurableEngine/SharedMemory.cs
@@ -45,18 +45,26 @@ namespace DurableEngine
         }
 
         /// <summary>
-        /// Blocks Orchestration-invoker thread, wakes up user-code thread.
-        /// This is usually used after the invoker has a result for the PS orchestrator.
+        /// Blocks Orchestration-invoker thread until the user-code thread completes or yields.
         /// </summary>
         /// <param name="completionHandle">The WaitHandle tracking if the user-code thread completed.</param>
         /// <returns>True if the user-code thread completed, False if it requests an API to be awaited.</returns>
-        public bool YieldToUserCodeThread(WaitHandle completionHandle)
+        public bool WaitForInvokerThreadTurn(WaitHandle completionHandle)
         {
 
             // Wake up when either the user-code returns, or when we're yielded-to for `await`'ing.
             var index = WaitHandle.WaitAny(new[] { completionHandle, invokerThreadTurn });
             var shouldStop = index == 0;
             return shouldStop;
+        }
+
+        /// <summary>
+        /// Wakes up the user-code thread without blocking the invoker thread.
+        /// The invoker thread should block itself afterwards to prevent races.
+        /// </summary>
+        public void WakeUserCodeThread()
+        {
+            userCodeThreadTurn.Set();
         }
     }
 }

--- a/src/DurableEngine/Tasks/DurableTask.cs
+++ b/src/DurableEngine/Tasks/DurableTask.cs
@@ -68,7 +68,6 @@ namespace DurableEngine.Tasks
                     OrchestrationContext.SharedMemory.Add(task.GetOrCreateAction());
                 }
 
-
                 // Signal orchestration thread to await the Task.
                 // This is necessary for DTFx to determine if a result exists for the Task.
                 OrchestrationContext.SharedMemory.YieldToInvokerThread();

--- a/src/DurableEngine/Tasks/DurableTask.cs
+++ b/src/DurableEngine/Tasks/DurableTask.cs
@@ -49,10 +49,6 @@ namespace DurableEngine.Tasks
         /// <param name="writeErr">Function to write an exception to the pipeline.</param>
         public void Execute(Action<object> write, Action<ErrorRecord> writeErr)
         {
-            // Ensure that a DurableTask in the usercode thread
-            // only executes while the orchestration-invoker thread is blocked.
-            OrchestrationContext.SharedMemory.GuaranteeUserCodeTurn();
-
             DurableTask task = this;
 
             if (NoWait)
@@ -71,6 +67,7 @@ namespace DurableEngine.Tasks
                     // generate and cache action
                     OrchestrationContext.SharedMemory.Add(task.GetOrCreateAction());
                 }
+
 
                 // Signal orchestration thread to await the Task.
                 // This is necessary for DTFx to determine if a result exists for the Task.


### PR DESCRIPTION
The standalone DF PS SDK manages two threads: (1) the user-code thread and (2) the DTFx thread. Only one thread can be active at a time, and yield control to any given thread using AutoReset events.

In today's implementation, in order to yield control to the other thread, we perform the following steps, in order:
(A) We wake the other thread
(B) We **manually** reset this thread's AutoReset event (there's technically no reason to do this, the autoresetevent should _automatically reset_ after its corresponding thread wakes up)
(C) We block this thread until the AutoReset event is signaled.

After step (A) but before step (B), it's possible for the complement thread to signal the yielding thread's autoreset event. If this occurs, then in step (B) we will discard the complement thread's signal because we reset the AutoReset event. At that point, the orchestrator gets stuck.

In this PR, we remove the redundant call to the `.Reset()` API to avoid this race condition. Now we rely solely on the automatic reset of this data structure.

This should fix: https://github.com/Azure/azure-functions-durable-powershell/issues/65