### PR TITLE
Add Version property to $Context

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,1 @@
+* Add Version property to $Context

--- a/src/DurableEngine/DurableEngine.csproj
+++ b/src/DurableEngine/DurableEngine.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DurableTask.Client" Version="1.0.0" />
-    <PackageReference Include="Microsoft.DurableTask.Worker" Version="1.0.0" />
+    <PackageReference Include="Microsoft.DurableTask.Client" Version="1.10.0" />
+    <PackageReference Include="Microsoft.DurableTask.Worker" Version="1.10.0" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.1" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/DurableEngine/Models/OrchestrationContext.cs
+++ b/src/DurableEngine/Models/OrchestrationContext.cs
@@ -24,7 +24,7 @@ namespace DurableEngine.Models
         /// </summary>
         [DataMember]
         public object Input
-        { 
+        {
             get => DTFxContext?.GetInput<object>();
         }
 
@@ -77,5 +77,10 @@ namespace DurableEngine.Models
         /// </summary>
         [DataMember]
         internal HistoryEvent[] History { get; set; }
+
+        /// <summary>
+        /// Gets the version of the current orchestration instance, which was set when the instance was created.
+        /// </summary>
+        public string Version => DTFxContext?.Version;
     }
 }

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/DurableClientTests.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/DurableClientTests.cs
@@ -84,7 +84,8 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
                 {
                     Assert.Equal("Completed", (string)finalStatusResponseBody.runtimeStatus);
                     Assert.Equal("Hello Tokyo", finalStatusResponseBody.output[0].ToString());
-                    Assert.Equal("Hello Seattle", finalStatusResponseBody.output[1].ToString());
+                    Assert.Equal("Context.Version: 1.0", finalStatusResponseBody.output[1].ToString());
+                    Assert.Equal("Hello Seattle", finalStatusResponseBody.output[2].ToString());
                 });
         }
 

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/OrchestrationTests.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/OrchestrationTests.cs
@@ -72,6 +72,7 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
                     Assert.Equal("True", finalStatusResponseBody.output[0].ToString());
                     Assert.Equal("Hello myInstanceId", finalStatusResponseBody.output[1].ToString());
                     Assert.Equal("False", finalStatusResponseBody.output[2].ToString());
+                    Assert.Equal("1.0", finalStatusResponseBody.output[3].ToString());
                 });
         }
     }

--- a/test/E2E/durableApp/DurableOrchestratorAccessContextProps/run.ps1
+++ b/test/E2E/durableApp/DurableOrchestratorAccessContextProps/run.ps1
@@ -5,4 +5,5 @@ $output = @()
 $output += $Context.IsReplaying
 $output += Invoke-DurableActivity -FunctionName 'Hello' -Input $Context.InstanceId
 $output += $Context.IsReplaying
+$output += $Context.Version
 $output

--- a/test/E2E/durableApp/SimpleOrchestrator/run.ps1
+++ b/test/E2E/durableApp/SimpleOrchestrator/run.ps1
@@ -7,3 +7,5 @@ $ErrorActionPreference = 'Stop'
 $output = Invoke-DurableActivity -FunctionName "Hello" -Input "Tokyo"
 
 $output
+
+"Context.Version: $($Context.Version)"

--- a/test/E2E/durableApp/extensions.csproj
+++ b/test/E2E/durableApp/extensions.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	<WarningsAsErrors></WarningsAsErrors>
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
   </ItemGroup>

--- a/test/E2E/durableApp/host.json
+++ b/test/E2E/durableApp/host.json
@@ -10,5 +10,10 @@
   },
   "managedDependency": {
     "enabled": true
+  },
+  "extensions": {
+    "durableTask": {
+      "defaultVersion": "1.0"
+    }
   }
 }


### PR DESCRIPTION
Add Version property to the `$Context` object passed to orchestrator functions, similar to https://github.com/Azure/azure-functions-powershell-worker/pull/1108.

As a result, PowerShell Functions users will be able to specify a version in **host.json**:

``` json
{
  "extensions": {
    "durableTask": {
      "defaultVersion": "2.0"
    }
  }
}
```

and check the orchestration version in their orchestrator functions in order to keep them backward compatible, for example:

``` powershell
if ($Context.Version -eq '1.0') {
    # Legacy code path
    Invoke-DurableActivity 'A'
} elseif ($Context.Version -eq '2.0') {
    # New code path
    Invoke-DurableActivity 'B'
}
```

**Note: Microsoft.Azure.WebJobs.Extensions.DurableTask 3.1.0+ is required for this to work properly.**

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)