### PR TITLE
Allow overriding orchestration version when starting orchestrations via APIs

### DIFF
--- a/src/AzureFunctions.PowerShell.Durable.SDK.psm1
+++ b/src/AzureFunctions.PowerShell.Durable.SDK.psm1
@@ -100,7 +100,11 @@ function Start-DurableOrchestration {
 
         [Parameter(
             ValueFromPipelineByPropertyName=$true)]
-        [string] $InstanceId
+        [string] $InstanceId,
+
+        [Parameter(
+            ValueFromPipelineByPropertyName=$true)]
+        [string] $Version
     )
 
     $ErrorActionPreference = 'Stop'
@@ -125,6 +129,12 @@ function Start-DurableOrchestration {
             $UriTemplate = $DurableClient.creationUrls.createNewInstancePostUri
             $UriTemplate.Replace('{functionName}', $FunctionName).Replace('[/{instanceId}]', "/$InstanceId")
         }
+
+    # Add version parameter to query string if provided
+    if ($Version) {
+        $separator = if ($Uri.Contains('?')) { '&' } else { '?' }
+        $Uri += "$separator" + "version=$([System.Web.HttpUtility]::UrlEncode($Version))"
+    }
 
     $Body = $InputObject | ConvertTo-Json -Compress -Depth 100
               

--- a/src/DurableEngine/Actions/CallSubOrchestratorAction.cs
+++ b/src/DurableEngine/Actions/CallSubOrchestratorAction.cs
@@ -22,12 +22,18 @@ namespace DurableEngine.Actions
         /// </summary>
         public readonly object Input;
 
-        internal CallSubOrchestratorAction(string functionName, object input, string instanceId)
+        /// <summary>
+        /// The version of the sub-orchestrator function.
+        /// </summary>
+        public readonly string Version;
+
+        internal CallSubOrchestratorAction(string functionName, object input, string instanceId, string version)
             : base(ActionType.CallSubOrchestrator)
         {
             FunctionName = functionName;
             Input = input;
             InstanceId = instanceId;
+            Version = version;
         }
     }
 }

--- a/src/DurableEngine/Actions/CallSubOrchestratorWithRetryAction.cs
+++ b/src/DurableEngine/Actions/CallSubOrchestratorWithRetryAction.cs
@@ -29,13 +29,19 @@ namespace DurableEngine.Actions
         /// </summary>
         public readonly Dictionary<string, object> RetryOptions;
 
-        internal CallSubOrchestratorWithRetryAction(string functionName, object input, string instanceId, RetryPolicy retryOptions)
+        /// <summary>
+        /// The version of the sub-orchestrator function.
+        /// </summary>
+        public readonly string Version;
+
+        internal CallSubOrchestratorWithRetryAction(string functionName, object input, string instanceId, RetryPolicy retryOptions, string version)
             : base(ActionType.CallSubOrchestratorWithRetry)
         {
             FunctionName = functionName;
             InstanceId = instanceId;
             Input = input;
             RetryOptions = retryOptions.RetryPolicyDictionary;
+            Version = version;
         }
     }
 }

--- a/src/DurableEngine/DurableEngine.csproj
+++ b/src/DurableEngine/DurableEngine.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DurableTask.Client" Version="1.11.0" />
-    <PackageReference Include="Microsoft.DurableTask.Worker" Version="1.11.0" />
+    <PackageReference Include="Microsoft.DurableTask.Client" Version="1.15.1" />
+    <PackageReference Include="Microsoft.DurableTask.Worker" Version="1.15.1" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.10" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/DurableEngine/Tasks/SubOrchestratorTask.cs
+++ b/src/DurableEngine/Tasks/SubOrchestratorTask.cs
@@ -20,11 +20,14 @@ namespace DurableEngine.Tasks
 
         private RetryPolicy RetryOptions { get; }
 
+        internal string Version { get; }
+
         public SubOrchestratorTask(
             string functionName,
             string instanceId,
             object functionInput,
             RetryPolicy retryOptions,
+            string version,
             SwitchParameter noWait,
             Hashtable privateData) : base(noWait, privateData)
         {
@@ -32,6 +35,7 @@ namespace DurableEngine.Tasks
             InstanceId = instanceId;
             Input = functionInput;
             RetryOptions = retryOptions;
+            Version = version;
         }
 
         internal override Task<object> CreateDTFxTask()
@@ -45,14 +49,19 @@ namespace DurableEngine.Tasks
                 ? taskOptions :
                 taskOptions.WithInstanceId(InstanceId);
 
-            return DTFxContext.CallSubOrchestratorAsync<object>(FunctionName, Input, taskOptions);
+            var subOrchestrationOptions = new SubOrchestrationOptions(taskOptions, InstanceId)
+            {
+                Version = this.Version
+            };
+
+            return DTFxContext.CallSubOrchestratorAsync<object>(FunctionName, Input, subOrchestrationOptions);
         }
 
         internal override OrchestrationAction CreateOrchestrationAction()
         {
             return RetryOptions == null
-                ? new CallSubOrchestratorAction(FunctionName, Input, InstanceId)
-                : new CallSubOrchestratorWithRetryAction(FunctionName, Input, InstanceId, RetryOptions);
+                ? new CallSubOrchestratorAction(FunctionName, Input, InstanceId, Version)
+                : new CallSubOrchestratorWithRetryAction(FunctionName, Input, InstanceId, RetryOptions, Version);
         }
     }
 }

--- a/src/DurableSDK/Commands/APIs/InvokeSubOrchestratorCommand.cs
+++ b/src/DurableSDK/Commands/APIs/InvokeSubOrchestratorCommand.cs
@@ -44,6 +44,13 @@ namespace DurableSDK.Commands.APIs
         public RetryPolicy RetryOptions { get; set; }
 
         /// <summary>
+        /// Version of the SubOrchestrator to invoke.
+        /// </summary>
+        [Parameter]
+        [ValidateNotNull]
+        public string Version { get; set; }
+
+        /// <summary>
         /// If provided, the Task will block and be scheduled immediately.
         /// Otherwise, a Task object is returned and the Task is not scheduled yet.
         /// </summary>
@@ -53,7 +60,7 @@ namespace DurableSDK.Commands.APIs
         internal override DurableTask CreateDurableTask()
         {
             var privateData = (Hashtable)MyInvocation.MyCommand.Module.PrivateData;
-            SubOrchestratorTask task = new SubOrchestratorTask(FunctionName, InstanceId, Input, RetryOptions, NoWait, privateData);
+            SubOrchestratorTask task = new SubOrchestratorTask(FunctionName, InstanceId, Input, RetryOptions, Version, NoWait, privateData);
             return task;
         }
     }

--- a/src/Help/Invoke-DurableSubOrchestrator.md
+++ b/src/Help/Invoke-DurableSubOrchestrator.md
@@ -14,7 +14,7 @@ Invokes a sub-orchestrator function.
 ## SYNTAX
 
 ```
-Invoke-DurableSubOrchestrator -FunctionName <String> [-InstanceId <String>] [-Input <Object>] [-RetryOptions <RetryPolicy>] [-NoWait] [<CommonParameters>]
+Invoke-DurableSubOrchestrator -FunctionName <String> [-InstanceId <String>] [-Input <Object>] [-RetryOptions <RetryPolicy>] [-Version <String>] [-NoWait] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,6 +45,15 @@ Write-Host "Sub-orchestrator completed with result: $batchResult"
 ```
 
 This example shows how to invoke a sub-orchestrator function asynchronously using -NoWait, which returns a task object that can be awaited later.
+
+### Example 3 - Specifying a version
+
+```powershell
+$result = Invoke-DurableSubOrchestrator -FunctionName "ChildOrchestrator" -Version "2.0" -Input @{ ProcessId = "proc456" }
+Write-Host "Sub-orchestrator (version 2.0) completed with result: $result"
+```
+
+This example shows how to invoke a sub-orchestrator with a specific version, overriding the default version configured in host.json.
 
 ## PARAMETERS
 
@@ -83,6 +92,22 @@ Accept wildcard characters: False
 ### -InstanceId
 
 An optional instance ID for the sub-orchestrator. If not specified, a unique instance ID will be automatically generated for the sub-orchestrator.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Version
+
+An optional version string for the sub-orchestrator function. When specified, this version overrides the default version configured in host.json for this specific sub-orchestrator invocation. This allows you to invoke specific versions of orchestrator functions.
 
 ```yaml
 Type: String
@@ -152,6 +177,7 @@ Returns the result of the sub-orchestrator execution by default. If -NoWait is s
 - Use the -NoWait parameter when you need to invoke multiple sub-orchestrators concurrently.
 - Sub-orchestrators inherit the fault-tolerance and replay characteristics of the parent orchestration.
 - The sub-orchestrator function name must match a function defined in your Azure Functions app with an orchestration trigger.
+- The -Version parameter allows you to invoke specific versions of orchestrator functions, overriding the default version from host.json.
 - Consider using sub-orchestrators to break down complex workflows into manageable, reusable components.
 
 ## RELATED LINKS

--- a/src/Help/Start-DurableOrchestration.md
+++ b/src/Help/Start-DurableOrchestration.md
@@ -14,7 +14,7 @@ Start a durable orchestration.
 ## SYNTAX
 
 ```
-Start-DurableOrchestration [-FunctionName] <String> [[-InputObject] <Object>] [-DurableClient <Object>] [-InstanceId <String>] [<CommonParameters>]
+Start-DurableOrchestration [-FunctionName] <String> [[-InputObject] <Object>] [-DurableClient <Object>] [-InstanceId <String>] [-Version <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -99,6 +99,24 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
+### -Version
+
+Optional orchestration version.
+The provided value will be available as `$Context.Version` within the orchestrator function context.
+If not specified, the default version specified by the `defaultVersion` property in the Function app's host.json will be used.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
@@ -116,6 +134,10 @@ You can pipe objects to the -InputObject parameter to provide input data for the
 ### System.String (InstanceId)
 
 You can pipe strings to the -InstanceId parameter to specify a custom instance ID for the orchestration.
+
+### System.String (Version)
+
+You can pipe strings to the -Version parameter to specify a version for the orchestration function.
 
 ## OUTPUTS
 

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/ActivityTests.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/ActivityTests.cs
@@ -23,7 +23,7 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
             Assert.Equal(HttpStatusCode.Accepted, initialResponse.StatusCode);
 
             var initialResponseBodyString = await initialResponse.Content.ReadAsStringAsync();
-            dynamic initialResponseBody = JsonConvert.DeserializeObject(initialResponseBodyString);
+            dynamic initialResponseBody = JsonConvert.DeserializeObject(initialResponseBodyString)!;
             var statusQueryGetUri = (string)initialResponseBody.statusQueryGetUri;
 
             var startTime = DateTime.UtcNow;
@@ -41,7 +41,7 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
                             {
                                 if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
                                 {
-                                    Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
+                                    Assert.Fail($"The orchestration has not completed after {_orchestrationCompletionTimeout}");
                                 }
                                 await Task.Delay(TimeSpan.FromSeconds(2));
                                 break;
@@ -56,7 +56,7 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
                             }
 
                         default:
-                            Assert.True(false, $"Unexpected orchestration status code: {statusResponse.StatusCode}");
+                            Assert.Fail($"Unexpected orchestration status code: {statusResponse.StatusCode}");
                             break;
                     }
                 }

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/Constants.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/Constants.cs
@@ -13,7 +13,7 @@ namespace AzureFunctions.PowerShell.Durable.SDK.Tests.E2E
         public static class Queue
         {
             public static string QueueName = "outqueue";
-            public static string StorageConnectionStringSetting = Environment.GetEnvironmentVariable("AzureWebJobsStorage");
+            public static string StorageConnectionStringSetting = Environment.GetEnvironmentVariable("AzureWebJobsStorage") ?? "AzureWebJobsStorage placeholder";
             public static string OutputBindingName = "test-output-ps";
             public static string InputBindingName = "test-input-ps";
         }    

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/DurableClientTests.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/DurableClientTests.cs
@@ -3,6 +3,7 @@
 
 using AzureFunctions.PowerShell.Durable.SDK.Tests.E2E;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Net;
 using Xunit;
 
@@ -258,6 +259,58 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
                     Assert.Equal("Completed", (string)finalStatusResponseBody.runtimeStatus);
                     Assert.Equal("FirstTimeout", finalStatusResponseBody.output[0].ToString());
                     Assert.Equal("SecondExternalEvent", finalStatusResponseBody.output[1].ToString());
+                });
+        }
+
+        [Theory]
+        // [InlineData(null, null, "1.0", "1.0")] // No version specified, should use defaultVersion from host.json for both
+        // [InlineData("0.5", null, "0.5", "1.0")] // Version specified for orchestrator, orchestrator should use it, suborchestrator should use defaultVersion
+        // [InlineData(null, "0.7", "1.0", "0.7")] // Version specified for suborchestrator only, orchestrator should use defaultVersion, suborchestrator should use specified version
+        [InlineData("0.5", "0.7", "0.5", "0.7")] // Both versions specified, each should use their respective versions
+        public async Task OrchestrationVersionIsPropagatedToContext(
+            string orchestratorVersion,
+            string subOrchestratorVersion,
+            string expectedOrchestratorVersion,
+            string expectedSubOrchestratorVersion)
+        {
+            var queryParams = new List<string>();
+            if (orchestratorVersion != null)
+                queryParams.Add($"Version={orchestratorVersion}");
+            if (subOrchestratorVersion != null)
+                queryParams.Add($"SubOrchestratorVersion={subOrchestratorVersion}");
+            
+            string queryString = queryParams.Count > 0 ? "?" + string.Join("&", queryParams) : string.Empty;
+            
+            var initialResponse = await Utilities.GetHttpStartResponse("VersionedOrchestrator", queryString);
+            Assert.Equal(HttpStatusCode.Accepted, initialResponse.StatusCode);
+
+            var location = initialResponse.Headers.Location;
+            Assert.NotNull(location);
+
+            await ValidateDurableWorkflowResults(
+                initialResponse,
+                validateInitialResponse: (dynamic initialResponseBody) =>
+                {
+                    Assert.NotNull(initialResponseBody.id);
+                    var statusQueryGetUri = (string)initialResponseBody.statusQueryGetUri;
+                    Assert.Equal(location?.ToString(), statusQueryGetUri);
+                    Assert.NotNull(initialResponseBody.sendEventPostUri);
+                    Assert.NotNull(initialResponseBody.purgeHistoryDeleteUri);
+                    Assert.NotNull(initialResponseBody.terminatePostUri);
+                    Assert.NotNull(initialResponseBody.rewindPostUri);
+                },
+                validateIntermediateResponse: (dynamic intermediateStatusResponseBody) =>
+                {
+                    var runtimeStatus = (string)intermediateStatusResponseBody.runtimeStatus;
+                    Assert.True(
+                        runtimeStatus == "Running" || runtimeStatus == "Pending",
+                        $"Unexpected runtime status: {runtimeStatus}");
+                },
+                validateFinalResponse: (dynamic finalStatusResponseBody) =>
+                {
+                    Assert.Equal("Completed", (string)finalStatusResponseBody.runtimeStatus);
+                    Assert.Equal(expectedOrchestratorVersion, finalStatusResponseBody.output[0].ToString());
+                    Assert.Equal(expectedSubOrchestratorVersion, finalStatusResponseBody.output[1].ToString());
                 });
         }
     }

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/DurableTests.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/DurableTests.cs
@@ -39,7 +39,7 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
             Action<dynamic>? validateFinalResponse = null)
         {
             var initialResponseBodyString = await initialResponse.Content.ReadAsStringAsync();
-            dynamic initialResponseBody = JsonConvert.DeserializeObject(initialResponseBodyString);
+            dynamic initialResponseBody = JsonConvert.DeserializeObject(initialResponseBodyString)!;
             var statusQueryGetUri = (string)initialResponseBody.statusQueryGetUri;
 
             validateInitialResponse?.Invoke(initialResponseBody);
@@ -63,7 +63,7 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
                         {
                             if (DateTime.UtcNow > startTime + _orchestrationCompletionTimeout)
                             {
-                                Assert.True(false, $"The orchestration has not completed after {_orchestrationCompletionTimeout}");
+                                Assert.Fail($"The orchestration has not completed after {_orchestrationCompletionTimeout}");
                             }
 
                             validateIntermediateResponse?.Invoke(statusResponseBody);
@@ -78,7 +78,7 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
                         }
 
                         default:
-                            Assert.True(false, $"Unexpected orchestration status code: {statusResponse.StatusCode}");
+                            Assert.Fail($"Unexpected orchestration status code: {statusResponse.StatusCode}");
                             break;
                     }
                 }

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/ExternalEventTests.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/ExternalEventTests.cs
@@ -26,7 +26,7 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
                 sendExternalEvents: async (HttpClient httpClient) =>
                 {
                     var initialResponseBodyString = await initialResponse.Content.ReadAsStringAsync();
-                    dynamic initialResponseBody = JsonConvert.DeserializeObject(initialResponseBodyString);
+                    dynamic initialResponseBody = JsonConvert.DeserializeObject(initialResponseBodyString)!;
                     var raiseEventUri = (string)initialResponseBody.sendEventPostUri;
 
                     raiseEventUri = raiseEventUri.Replace("{eventName}", "TESTEVENTNAME");

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/Utilities.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/Utilities.cs
@@ -51,7 +51,7 @@ namespace AzureFunctions.PowerShell.Durable.SDK.Tests.E2E
         public static async Task<dynamic> GetResponseBodyAsync(HttpResponseMessage response)
         {
             var responseBody = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject(responseBody);
+            return JsonConvert.DeserializeObject(responseBody)!;
         }
     }
 }

--- a/test/E2E/durableApp/DurableClient/run.ps1
+++ b/test/E2E/durableApp/DurableClient/run.ps1
@@ -6,7 +6,24 @@ $ErrorActionPreference = 'Stop'
 Write-Host "DurableClient started"
 
 $FunctionName = $Request.Params.FunctionName
-$InstanceId = Start-DurableOrchestration -FunctionName $FunctionName
+
+$Version = $Request.Query.Version
+$SubOrchestratorVersion = $Request.Query.SubOrchestratorVersion
+
+$InputObject = if ($SubOrchestratorVersion) {
+    @{ SubOrchestratorVersion = $SubOrchestratorVersion }
+} else {
+    $null
+}
+
+if ($Version) {
+    Write-Host "Starting orchestration '$FunctionName' with Version '$Version'"
+    $InstanceId = Start-DurableOrchestration -FunctionName $FunctionName -Version $Version -InputObject $InputObject
+} else {
+    Write-Host "Starting orchestration '$FunctionName' with default version"
+    $InstanceId = Start-DurableOrchestration -FunctionName $FunctionName -InputObject $InputObject
+}
+
 Write-Host "Started orchestration with ID = '$InstanceId'"
 
 $Response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $InstanceId

--- a/test/E2E/durableApp/VersionedOrchestrator/function.json
+++ b/test/E2E/durableApp/VersionedOrchestrator/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/durableApp/VersionedOrchestrator/run.ps1
+++ b/test/E2E/durableApp/VersionedOrchestrator/run.ps1
@@ -1,0 +1,14 @@
+using namespace System.Net
+
+param($Context)
+
+$ErrorActionPreference = 'Stop'
+
+$reportedSubOrchestratorVersion =
+    if ($Context.Input -and $Context.Input.SubOrchestratorVersion) {
+        Invoke-DurableSubOrchestrator -FunctionName "VersionedSubOrchestrator" -Version $Context.Input.SubOrchestratorVersion
+    } else {
+        Invoke-DurableSubOrchestrator -FunctionName "VersionedSubOrchestrator"
+    }
+
+return @($Context.Version, $reportedSubOrchestratorVersion)

--- a/test/E2E/durableApp/VersionedSubOrchestrator/function.json
+++ b/test/E2E/durableApp/VersionedSubOrchestrator/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "name": "Context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/E2E/durableApp/VersionedSubOrchestrator/run.ps1
+++ b/test/E2E/durableApp/VersionedSubOrchestrator/run.ps1
@@ -1,0 +1,9 @@
+using namespace System.Net
+
+param($Context)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Warning "VersionedSubOrchestrator: $($Context.Version)"
+
+return $Context.Version

--- a/test/E2E/durableApp/extensions.csproj
+++ b/test/E2E/durableApp/extensions.csproj
@@ -5,7 +5,7 @@
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="3.5.1-anatolib-ver.8" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Allow overriding orchestration version when starting orchestrations via APIs by adding `Version` parameter to `Start-DurableOrchestration` and `Invoke-SubOrchestrator`.