### PR TITLE
Update PowerShell SDK to 7.4.15

### DIFF
--- a/src/DurableEngine/DurableEngine.csproj
+++ b/src/DurableEngine/DurableEngine.csproj
@@ -9,6 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DurableTask.Client" Version="1.20.0" />
     <PackageReference Include="Microsoft.DurableTask.Worker" Version="1.20.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.13" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.15" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/DurableSDK/DurableSDK.csproj
+++ b/src/DurableSDK/DurableSDK.csproj
@@ -8,6 +8,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DurableEngine\DurableEngine.csproj" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.13" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.15" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Updates `Microsoft.PowerShell.SDK` from 7.4.13 to 7.4.15 in DurableEngine and DurableSDK.
- Remediates CVE-2026-26171 and CVE-2026-33116 through the upstream `System.Security.Cryptography.Xml` 8.0.3 resolution.

## Validation
- `dotnet restore src/DurableSDK/DurableSDK.csproj`
- `dotnet build src/DurableSDK/DurableSDK.csproj --no-restore`
- `dotnet list src/DurableEngine/DurableEngine.csproj package --include-transitive` resolved `System.Security.Cryptography.Xml` 8.0.3.
- `dotnet list src/DurableSDK/DurableSDK.csproj package --include-transitive` resolved `System.Security.Cryptography.Xml` 8.0.3.