### PR TITLE
Update module version to 2.3.0

### DIFF
--- a/src/AzureFunctions.PowerShell.Durable.SDK.psd1
+++ b/src/AzureFunctions.PowerShell.Durable.SDK.psd1
@@ -1,6 +1,6 @@
 @{    
     # Version number of this module.
-    ModuleVersion = '2.2.0'
+    ModuleVersion = '2.3.0'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')

--- a/src/DurableEngine/DurableEngine.csproj
+++ b/src/DurableEngine/DurableEngine.csproj
@@ -9,6 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DurableTask.Client" Version="1.20.0" />
     <PackageReference Include="Microsoft.DurableTask.Worker" Version="1.20.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.15" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.18" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/DurableSDK/DurableSDK.csproj
+++ b/src/DurableSDK/DurableSDK.csproj
@@ -8,6 +8,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DurableEngine\DurableEngine.csproj" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.15" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.18" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Bumps the module version from `2.2.0` to `2.3.0` so a new release can be published to the PowerShell Gallery. Also bumps the PS SDK version to 7.4.18 to update transitives. 

Minor version bump per the repo convention (feature additions get a minor bump), covering the pending change in `release_notes.md`:

* Add `Version` property to `$Context`

## Changes

* `src/AzureFunctions.PowerShell.Durable.SDK.psd1`: `ModuleVersion` `2.2.0` → `2.3.0`
