### PR TITLE
Support legacy Durable history payloads

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,43 @@
+# Copilot instructions
+
+## Repository structure
+
+- `src/DurableSDK/` builds `AzureFunctions.PowerShell.Durable.SDK.dll`, the binary PowerShell module loaded into the worker's default assembly load context (ALC). It contains exported cmdlets, module initialization, and the ALC bootstrap.
+- `src/DurableEngine/` builds `DurableEngine.dll`, which contains orchestration replay, Durable Task integration, models, and other implementation that depends on Durable Task assemblies.
+- `src/AzureFunctions.PowerShell.Durable.SDK.psm1` contains the script-based public commands.
+- `src/AzureFunctions.PowerShell.Durable.SDK.psd1` is the module manifest and defines the exported commands, aliases, and minimum PowerShell version.
+- `src/Help/` contains the source Markdown for generated external help.
+- `test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/` contains the xUnit test project. Most tests launch a real Functions host against the packaged module.
+- `test/E2E/durableApp/` is the PowerShell Functions app used by E2E tests. `build.ps1` publishes the module into its `Modules/` directory.
+- `build.ps1` is the authoritative packaging path. It publishes both C# projects, places `DurableEngine.dll` and its dependencies under `Dependencies/`, copies the top-level SDK assembly and module files, and generates external help.
+
+## Assembly load context and dependency isolation
+
+The module intentionally separates its assemblies to avoid conflicts with assemblies already loaded by the PowerShell worker:
+
+1. `AzureFunctions.PowerShell.Durable.SDK.dll` loads in the default ALC as a nested PowerShell module.
+2. Its `ModuleInitializer` registers a default-ALC resolver for `DurableEngine` only.
+3. `DurableEngine.dll` loads in `DependencyAssemblyLoadContext`.
+4. That custom ALC resolves assemblies from the packaged `Dependencies/` directory, including `DurableTask.Core` and the Microsoft Durable Task worker/client libraries.
+
+Preserve these contracts:
+
+- Code that directly references Durable Task implementation types, including `DurableTask.Core.*`, belongs in `DurableEngine`, not `DurableSDK`.
+- Do not add Durable Task package references directly to `DurableSDK`.
+- Keep the default/custom ALC boundary limited to SDK-owned types and framework types whose identity is shared with the worker, such as `System.*` and `System.Management.Automation`.
+- Do not return, cast, store in framework collections, or deserialize custom-ALC Durable Task objects in default-ALC code. Type names can match while runtime type identity differs, causing missing-assembly, invalid-cast, or array-type-mismatch failures.
+- Perform creation, serialization, deserialization, and collection construction involving Durable Task types entirely inside `DurableEngine`. Expose an SDK-owned operation or result across the boundary instead of exposing Durable Task objects.
+- Treat Newtonsoft.Json carefully at the boundary. Type-preserving payloads can contain `$type` metadata for Durable Task classes; ensure those types are resolved and materialized in the same ALC as their destination model and collections.
+- If a new dependency is needed by orchestration internals, add it to `DurableEngine` and confirm `build.ps1` places it under `Dependencies/`.
+- Do not broaden the default ALC resolver to load all dependencies unless the isolation design is intentionally being replaced and fully tested.
+
+Unit tests that reference the projects directly run in a single test-process loading environment and do not prove packaged-module ALC correctness. Any change involving project references, assembly placement, JSON type metadata, or Durable Task types must also be tested through the packaged module and a real Functions host.
+
+## Build and test
+
+- Use `dotnet build .\src\DurableSDK.sln --configuration Release` for a fast compile check.
+- Use `.\build.ps1 -Configuration Release` to validate the actual module layout.
+- Run focused xUnit tests with `dotnet test .\test\E2E\AzureFunctions.PowerShell.Durable.SDK.E2E\AzureFunctions.PowerShell.Durable.SDK.E2E.csproj --filter <filter>`.
+- Run `.\test\E2E\Start-E2ETest.ps1 -NoBuild` after packaging for changes affecting orchestration, module loading, dependency resolution, or worker/extension payloads. Ensure Azurite is available and running.
+
+Keep changes compatible with both legacy Durable extension payloads and current type-preserving payloads unless a deliberate breaking change is approved.

--- a/src/DurableEngine/Converters/HistoryEventConverter.cs
+++ b/src/DurableEngine/Converters/HistoryEventConverter.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-namespace DurableSDK.Converters
+namespace DurableEngine.Converters
 {
     using System;
     using DurableTask.Core.History;
@@ -31,6 +31,11 @@ namespace DurableSDK.Converters
             }
 
             var eventObject = JObject.Load(reader);
+            if (eventObject.Property("$type", StringComparison.Ordinal) != null)
+            {
+                return DeserializeTypePreservingEvent(eventObject, objectType, serializer);
+            }
+
             var eventTypeToken = eventObject.GetValue(
                 nameof(HistoryEvent.EventType),
                 StringComparison.OrdinalIgnoreCase);
@@ -62,6 +67,26 @@ namespace DurableSDK.Converters
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             throw new NotSupportedException();
+        }
+
+        private object DeserializeTypePreservingEvent(
+            JObject eventObject,
+            Type objectType,
+            JsonSerializer serializer)
+        {
+            int converterIndex = serializer.Converters.IndexOf(this);
+            serializer.Converters.RemoveAt(converterIndex);
+
+            try
+            {
+                return eventObject.ToObject(objectType, serializer)
+                    ?? throw new JsonSerializationException(
+                        "Type-preserving history event could not be deserialized.");
+            }
+            finally
+            {
+                serializer.Converters.Insert(converterIndex, this);
+            }
         }
 
         private static ExecutionRewoundEvent DeserializeExecutionRewoundEvent(

--- a/src/DurableEngine/DurableEngine.csproj
+++ b/src/DurableEngine/DurableEngine.csproj
@@ -11,4 +11,9 @@
     <PackageReference Include="Microsoft.DurableTask.Worker" Version="1.20.0" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.18" PrivateAssets="all" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="AzureFunctions.PowerShell.Durable.SDK" />
+    <InternalsVisibleTo Include="AzureFunctions.PowerShell.Durable.SDK.E2E" />
+  </ItemGroup>
 </Project>

--- a/src/DurableEngine/Models/OrchestrationContext.cs
+++ b/src/DurableEngine/Models/OrchestrationContext.cs
@@ -9,7 +9,9 @@
 namespace DurableEngine.Models
 {
     using global::DurableTask.Core.History;
+    using DurableEngine.Converters;
     using Microsoft.DurableTask;
+    using Newtonsoft.Json;
     using System;
     using System.Runtime.Serialization;
 
@@ -71,6 +73,19 @@ namespace DurableEngine.Models
         /// DTFx context that provides the implementation of DF APis.
         /// </summary>
         internal TaskOrchestrationContext DTFxContext;
+
+        internal static OrchestrationContext Deserialize(string orchestrationContext)
+        {
+            var serializerSettings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All,
+                Converters = { new HistoryEventConverter() },
+            };
+
+            return JsonConvert.DeserializeObject<OrchestrationContext>(
+                orchestrationContext,
+                serializerSettings);
+        }
 
         /// <summary>
         /// Internal orchestrator history

--- a/src/DurableSDK/Commands/Internals/SetFunctionInvocationContextCommand.cs
+++ b/src/DurableSDK/Commands/Internals/SetFunctionInvocationContextCommand.cs
@@ -13,6 +13,7 @@ namespace DurableSDK.Commands.Internals
     using System.Management.Automation;
     using DurableEngine;
     using DurableEngine.Models;
+    using DurableSDK.Converters;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -59,7 +60,8 @@ namespace DurableSDK.Commands.Internals
                     // De-serialize the orchestration context
                     JsonSerializerSettings serializerSettings = new JsonSerializerSettings
                     {
-                        TypeNameHandling = TypeNameHandling.All
+                        TypeNameHandling = TypeNameHandling.All,
+                        Converters = { new HistoryEventConverter() }
                     };
 
                     var context = JsonConvert.DeserializeObject<OrchestrationContext>(OrchestrationContext, serializerSettings);

--- a/src/DurableSDK/Commands/Internals/SetFunctionInvocationContextCommand.cs
+++ b/src/DurableSDK/Commands/Internals/SetFunctionInvocationContextCommand.cs
@@ -13,8 +13,6 @@ namespace DurableSDK.Commands.Internals
     using System.Management.Automation;
     using DurableEngine;
     using DurableEngine.Models;
-    using DurableSDK.Converters;
-    using Newtonsoft.Json;
 
     /// <summary>
     /// Sets either the orchestration context or the durableClient in the privateData of this module or clears both.
@@ -57,14 +55,7 @@ namespace DurableSDK.Commands.Internals
             switch (ParameterSetName)
             {
                 case ContextKey:
-                    // De-serialize the orchestration context
-                    JsonSerializerSettings serializerSettings = new JsonSerializerSettings
-                    {
-                        TypeNameHandling = TypeNameHandling.All,
-                        Converters = { new HistoryEventConverter() }
-                    };
-
-                    var context = JsonConvert.DeserializeObject<OrchestrationContext>(OrchestrationContext, serializerSettings);
+                    var context = DurableEngine.Models.OrchestrationContext.Deserialize(this.OrchestrationContext);
 
                     // save orchestration context to privateData
                     privateData[ContextKey] = context;

--- a/src/DurableSDK/Converters/HistoryEventConverter.cs
+++ b/src/DurableSDK/Converters/HistoryEventConverter.cs
@@ -1,0 +1,115 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DurableSDK.Converters
+{
+    using System;
+    using DurableTask.Core.History;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    internal sealed class HistoryEventConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(HistoryEvent);
+        }
+
+        public override object ReadJson(
+            JsonReader reader,
+            Type objectType,
+            object existingValue,
+            JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            var eventObject = JObject.Load(reader);
+            var eventTypeToken = eventObject.GetValue(
+                nameof(HistoryEvent.EventType),
+                StringComparison.OrdinalIgnoreCase);
+
+            if (eventTypeToken == null)
+            {
+                throw new JsonSerializationException(
+                    $"History event is missing the required '{nameof(HistoryEvent.EventType)}' property.");
+            }
+
+            if (!Enum.TryParse(eventTypeToken.ToString(), ignoreCase: true, out EventType eventType)
+                || !Enum.IsDefined(typeof(EventType), eventType))
+            {
+                throw new JsonSerializationException(
+                    $"History event contains unsupported EventType value '{eventTypeToken}'.");
+            }
+
+            Type concreteType = GetConcreteType(eventType);
+            if (concreteType == typeof(ExecutionRewoundEvent))
+            {
+                return DeserializeExecutionRewoundEvent(eventObject, serializer);
+            }
+
+            return eventObject.ToObject(concreteType, serializer)
+                ?? throw new JsonSerializationException(
+                    $"History event of type '{eventType}' could not be deserialized.");
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotSupportedException();
+        }
+
+        private static ExecutionRewoundEvent DeserializeExecutionRewoundEvent(
+            JObject eventObject,
+            JsonSerializer serializer)
+        {
+            int? eventId = eventObject.Value<int?>(nameof(HistoryEvent.EventId));
+            if (!eventId.HasValue)
+            {
+                throw new JsonSerializationException(
+                    $"History event is missing the required '{nameof(HistoryEvent.EventId)}' property.");
+            }
+
+            // This event has multiple parameterized constructors, so Newtonsoft cannot select one automatically.
+            var historyEvent = new ExecutionRewoundEvent(eventId.Value);
+            using JsonReader eventReader = eventObject.CreateReader();
+            serializer.Populate(eventReader, historyEvent);
+            return historyEvent;
+        }
+
+        private static Type GetConcreteType(EventType eventType)
+        {
+            return eventType switch
+            {
+                EventType.ExecutionStarted => typeof(ExecutionStartedEvent),
+                EventType.ExecutionCompleted => typeof(ExecutionCompletedEvent),
+                EventType.ExecutionTerminated => typeof(ExecutionTerminatedEvent),
+                EventType.TaskScheduled => typeof(TaskScheduledEvent),
+                EventType.TaskCompleted => typeof(TaskCompletedEvent),
+                EventType.TaskFailed => typeof(TaskFailedEvent),
+                EventType.SubOrchestrationInstanceCreated => typeof(SubOrchestrationInstanceCreatedEvent),
+                EventType.SubOrchestrationInstanceCompleted => typeof(SubOrchestrationInstanceCompletedEvent),
+                EventType.SubOrchestrationInstanceFailed => typeof(SubOrchestrationInstanceFailedEvent),
+                EventType.TimerCreated => typeof(TimerCreatedEvent),
+                EventType.TimerFired => typeof(TimerFiredEvent),
+                EventType.OrchestratorStarted => typeof(OrchestratorStartedEvent),
+                EventType.OrchestratorCompleted => typeof(OrchestratorCompletedEvent),
+                EventType.EventSent => typeof(EventSentEvent),
+                EventType.EventRaised => typeof(EventRaisedEvent),
+                EventType.ContinueAsNew => typeof(ContinueAsNewEvent),
+                EventType.GenericEvent => typeof(GenericEvent),
+                EventType.HistoryState => typeof(HistoryStateEvent),
+                EventType.ExecutionSuspended => typeof(ExecutionSuspendedEvent),
+                EventType.ExecutionResumed => typeof(ExecutionResumedEvent),
+                EventType.ExecutionRewound => typeof(ExecutionRewoundEvent),
+                _ => throw new JsonSerializationException(
+                    $"History event type '{eventType}' has no concrete DurableTask history event class."),
+            };
+        }
+    }
+}

--- a/src/DurableSDK/DurableSDK.csproj
+++ b/src/DurableSDK/DurableSDK.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\DurableEngine\DurableEngine.csproj" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.18" PrivateAssets="all" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="AzureFunctions.PowerShell.Durable.SDK.E2E" />
+  </ItemGroup>
 </Project>

--- a/src/DurableSDK/DurableSDK.csproj
+++ b/src/DurableSDK/DurableSDK.csproj
@@ -11,7 +11,4 @@
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.18" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="AzureFunctions.PowerShell.Durable.SDK.E2E" />
-  </ItemGroup>
 </Project>

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/AzureFunctions.PowerShell.Durable.SDK.E2E.csproj
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/AzureFunctions.PowerShell.Durable.SDK.E2E.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\DurableSDK\DurableSDK.csproj" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/AzureFunctions.PowerShell.Durable.SDK.E2E.csproj
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/AzureFunctions.PowerShell.Durable.SDK.E2E.csproj
@@ -9,9 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\DurableSDK\DurableSDK.csproj" />
+    <ProjectReference Include="..\..\..\src\DurableEngine\DurableEngine.csproj" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.18" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/HistoryEventConverterTests.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/HistoryEventConverterTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using DurableSDK.Converters;
+using DurableEngine.Models;
 using DurableTask.Core.History;
 using Newtonsoft.Json;
 using Xunit;
@@ -48,10 +48,10 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
                 }
                 """;
 
-            HistoryEvent historyEvent = JsonConvert.DeserializeObject<HistoryEvent>(
-                json,
-                CreateSerializerSettings())!;
+            OrchestrationContext context = OrchestrationContext.Deserialize(
+                $$"""{ "history": [{{json}}], "instanceId": "test" }""");
 
+            HistoryEvent historyEvent = Assert.Single(context.History);
             Assert.IsType(expectedType, historyEvent);
             Assert.Equal(1, historyEvent.EventId);
         }
@@ -63,12 +63,12 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
             string json = JsonConvert.SerializeObject(
                 original,
                 typeof(HistoryEvent),
-                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
+                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
 
-            HistoryEvent historyEvent = JsonConvert.DeserializeObject<HistoryEvent>(
-                json,
-                CreateSerializerSettings())!;
+            OrchestrationContext context = OrchestrationContext.Deserialize(
+                $$"""{ "history": [{{json}}], "instanceId": "test" }""");
 
+            HistoryEvent historyEvent = Assert.Single(context.History);
             var taskScheduled = Assert.IsType<TaskScheduledEvent>(historyEvent);
             Assert.Equal(7, taskScheduled.EventId);
             Assert.Equal("Hello", taskScheduled.Name);
@@ -82,16 +82,8 @@ namespace AzureFunctions.PowerShell.Durable.SDK.E2E
         public void RejectsHistoryEventsWithoutConcreteTypes(string json)
         {
             Assert.Throws<JsonSerializationException>(
-                () => JsonConvert.DeserializeObject<HistoryEvent>(json, CreateSerializerSettings()));
-        }
-
-        private static JsonSerializerSettings CreateSerializerSettings()
-        {
-            return new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.All,
-                Converters = { new HistoryEventConverter() },
-            };
+                () => OrchestrationContext.Deserialize(
+                    $$"""{ "history": [{{json}}], "instanceId": "test" }"""));
         }
     }
 }

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/HistoryEventConverterTests.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/HistoryEventConverterTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using DurableSDK.Converters;
+using DurableTask.Core.History;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace AzureFunctions.PowerShell.Durable.SDK.E2E
+{
+    public class HistoryEventConverterTests
+    {
+        public static TheoryData<EventType, Type> SupportedEventTypes => new()
+        {
+            { EventType.ExecutionStarted, typeof(ExecutionStartedEvent) },
+            { EventType.ExecutionCompleted, typeof(ExecutionCompletedEvent) },
+            { EventType.ExecutionTerminated, typeof(ExecutionTerminatedEvent) },
+            { EventType.TaskScheduled, typeof(TaskScheduledEvent) },
+            { EventType.TaskCompleted, typeof(TaskCompletedEvent) },
+            { EventType.TaskFailed, typeof(TaskFailedEvent) },
+            { EventType.SubOrchestrationInstanceCreated, typeof(SubOrchestrationInstanceCreatedEvent) },
+            { EventType.SubOrchestrationInstanceCompleted, typeof(SubOrchestrationInstanceCompletedEvent) },
+            { EventType.SubOrchestrationInstanceFailed, typeof(SubOrchestrationInstanceFailedEvent) },
+            { EventType.TimerCreated, typeof(TimerCreatedEvent) },
+            { EventType.TimerFired, typeof(TimerFiredEvent) },
+            { EventType.OrchestratorStarted, typeof(OrchestratorStartedEvent) },
+            { EventType.OrchestratorCompleted, typeof(OrchestratorCompletedEvent) },
+            { EventType.EventSent, typeof(EventSentEvent) },
+            { EventType.EventRaised, typeof(EventRaisedEvent) },
+            { EventType.ContinueAsNew, typeof(ContinueAsNewEvent) },
+            { EventType.GenericEvent, typeof(GenericEvent) },
+            { EventType.HistoryState, typeof(HistoryStateEvent) },
+            { EventType.ExecutionSuspended, typeof(ExecutionSuspendedEvent) },
+            { EventType.ExecutionResumed, typeof(ExecutionResumedEvent) },
+            { EventType.ExecutionRewound, typeof(ExecutionRewoundEvent) },
+        };
+
+        [Theory]
+        [MemberData(nameof(SupportedEventTypes))]
+        public void DeserializesLegacyHistoryEvents(EventType eventType, Type expectedType)
+        {
+            string json = $$"""
+                {
+                  "EventType": {{(int)eventType}},
+                  "EventId": 1,
+                  "IsPlayed": false,
+                  "Timestamp": "2026-08-05T00:00:00Z"
+                }
+                """;
+
+            HistoryEvent historyEvent = JsonConvert.DeserializeObject<HistoryEvent>(
+                json,
+                CreateSerializerSettings())!;
+
+            Assert.IsType(expectedType, historyEvent);
+            Assert.Equal(1, historyEvent.EventId);
+        }
+
+        [Fact]
+        public void DeserializesTypePreservingHistoryEvents()
+        {
+            var original = new TaskScheduledEvent(7, "Hello", string.Empty, "{}");
+            string json = JsonConvert.SerializeObject(
+                original,
+                typeof(HistoryEvent),
+                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
+
+            HistoryEvent historyEvent = JsonConvert.DeserializeObject<HistoryEvent>(
+                json,
+                CreateSerializerSettings())!;
+
+            var taskScheduled = Assert.IsType<TaskScheduledEvent>(historyEvent);
+            Assert.Equal(7, taskScheduled.EventId);
+            Assert.Equal("Hello", taskScheduled.Name);
+            Assert.Equal("{}", taskScheduled.Input);
+        }
+
+        [Theory]
+        [InlineData("{}")]
+        [InlineData("""{ "EventType": 999 }""")]
+        [InlineData("""{ "EventType": 2 }""")]
+        public void RejectsHistoryEventsWithoutConcreteTypes(string json)
+        {
+            Assert.Throws<JsonSerializationException>(
+                () => JsonConvert.DeserializeObject<HistoryEvent>(json, CreateSerializerSettings()));
+        }
+
+        private static JsonSerializerSettings CreateSerializerSettings()
+        {
+            return new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All,
+                Converters = { new HistoryEventConverter() },
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- deserialize orchestration history events from the legacy payload shape using the existing `EventType` discriminator
- preserve compatibility with type-preserving `$type` payloads
- handle every concrete DurableTask history event class and fail clearly for unsupported discriminators
- add focused coverage for all event mappings, malformed payloads, and both serialization formats

## Validation

- `dotnet test .\test\E2E\AzureFunctions.PowerShell.Durable.SDK.E2E\AzureFunctions.PowerShell.Durable.SDK.E2E.csproj --filter FullyQualifiedName~HistoryEventConverterTests --no-restore`
- `dotnet build .\src\DurableSDK.sln --configuration Release --no-restore`

Partially addresses Azure/azure-functions-powershell-worker#1154, though an extension-correctness fix is probably still warranted