### PR TITLE
Improve errors for orchestration cmdlets outside orchestrators

### DIFF
--- a/src/DurableEngine/Tasks/DurableTask.cs
+++ b/src/DurableEngine/Tasks/DurableTask.cs
@@ -14,7 +14,14 @@ namespace DurableEngine.Tasks
         public DurableTask(SwitchParameter noWait, Hashtable privateData)
         {
             NoWait = noWait;
-            OrchestrationContext = (OrchestrationContext)privateData[OrchestrationInvoker.ContextKey];
+            OrchestrationContext = (OrchestrationContext)privateData?[OrchestrationInvoker.ContextKey];
+
+            if (OrchestrationContext == null)
+            {
+                throw new InvalidOperationException(
+                    "Durable orchestration cmdlets can only be used within orchestrator functions, " +
+                    "not in activity functions or client functions.");
+            }
         }
 
         private OrchestrationAction action;

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/AzureFunctions.PowerShell.Durable.SDK.E2E.csproj
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/AzureFunctions.PowerShell.Durable.SDK.E2E.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.18" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -21,6 +22,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\DurableEngine\DurableEngine.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/DurableTaskTests.cs
+++ b/test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/DurableTaskTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using DurableEngine.Models;
+using DurableEngine.Tasks;
+using System.Collections;
+using Xunit;
+
+namespace AzureFunctions.PowerShell.Durable.SDK.E2E
+{
+    public class DurableTaskTests
+    {
+        [Fact]
+        public void DurableTimerTaskWithoutOrchestrationContextThrowsInformativeException()
+        {
+            var privateData = new Hashtable();
+
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => new DurableTimerTask(TimeSpan.Zero, noWait: default, privateData));
+
+            Assert.Equal(
+                "Durable orchestration cmdlets can only be used within orchestrator functions, " +
+                "not in activity functions or client functions.",
+                exception.Message);
+        }
+
+        [Fact]
+        public void DurableTaskWithOrchestrationContextCanBeConstructed()
+        {
+            var orchestrationContext = new OrchestrationContext();
+            var privateData = new Hashtable
+            {
+                [DurableEngine.OrchestrationInvoker.ContextKey] = orchestrationContext,
+            };
+
+            var task = new ExternalEventTask("TestEvent", noWait: default, privateData);
+
+            Assert.NotNull(task);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- validate the orchestration context before constructing durable tasks
- replace the opaque `NullReferenceException` from orchestration-only cmdlets used in activity or client functions with an actionable error
- add regressions for both missing and valid orchestration contexts

## Testing

- `dotnet test test/E2E/AzureFunctions.PowerShell.Durable.SDK.E2E/AzureFunctions.PowerShell.Durable.SDK.E2E.csproj -c Release --filter "FullyQualifiedName~DurableTaskTests"`
- `./build.ps1 -Configuration Release`
- imported the built module and verified `Start-DurableTimer` outside an orchestrator returns the new error

Fixes Azure/azure-functions-durable-extension#2706