### PR TITLE
Update module version to 2.4.0

### DIFF
--- a/src/AzureFunctions.PowerShell.Durable.SDK.psd1
+++ b/src/AzureFunctions.PowerShell.Durable.SDK.psd1
@@ -1,6 +1,6 @@
 @{    
     # Version number of this module.
-    ModuleVersion = '2.3.0'
+    ModuleVersion = '2.4.0'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')


### PR DESCRIPTION
## Summary

Bumps the module version from `2.3.0` to `2.4.0` so a new release can be published to the PowerShell Gallery.

Minor version bump per the repo convention, covering changes since `v2.3.0`, including support for legacy Durable history payloads and reduced build-time public egress.

## Changes

* `src/AzureFunctions.PowerShell.Durable.SDK.psd1`: `ModuleVersion` `2.3.0` → `2.4.0`