### PR TITLE
Auto-generated baselines by 1ES Pipeline Templates

### DIFF
--- a/.config/1espt/PipelineAutobaseliningConfig.yml
+++ b/.config/1espt/PipelineAutobaseliningConfig.yml
@@ -1,0 +1,3 @@
+## DO NOT MODIFY THIS FILE MANUALLY. This is part of auto-baselining from 1ES Pipeline Templates. Go to [https://aka.ms/1espt-autobaselining] for more details.
+
+pipelines: {663: {retail: {source: {eslint: {lastModifiedDate: 2026-08-27}, psscriptanalyzer: {lastModifiedDate: 2026-08-27}, armory: {lastModifiedDate: 2026-08-27}}, binary: {binskim: {lastModifiedDate: 2026-08-27}, spotbugs: {lastModifiedDate: 2026-08-27}}}}}

--- a/.config/guardian/.gdnbaselines
+++ b/.config/guardian/.gdnbaselines
@@ -1,0 +1,53 @@
+{
+  "properties": {
+    "helpUri": "https://eng.ms/docs/microsoft-security/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/microsoft-guardian/general/baselines"
+  },
+  "version": "1.0.0",
+  "baselines": {
+    "default": {
+      "name": "default",
+      "createdDate": "2026-08-11 06:06:41Z",
+      "lastUpdatedDate": "2026-08-11 06:06:41Z"
+    }
+  },
+  "results": {
+    "9b12dcf64c186b6965664f68ea822e9646238d9d3923656ee2c1f29b72eeabfd": {
+      "signature": "9b12dcf64c186b6965664f68ea822e9646238d9d3923656ee2c1f29b72eeabfd",
+      "alternativeSignatures": [
+        "fdd0b1165adcd0bf66ceea59635a91aea9fee4efe463f34420c646453e841651",
+        "b29f636a8d9f54e9a15c85ce0e453a2111e0eedbbf4a856486a03b1b8b3d8029",
+        "297058fb1619ae05c9894fc3a0e7eb26d76e1543fd19a604a5544bd2da0f776e"
+      ],
+      "target": "src/DurableEngine/Models/OrchestrationContext.cs",
+      "line": 81,
+      "uriBaseId": "file:///D:/a/_work/1/s/",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "roslynanalyzers",
+      "ruleId": "CA2326",
+      "createdDate": "2026-08-27 17:20:25Z",
+      "expirationDate": "2027-02-13 17:21:39Z",
+      "justification": "This error is baselined with an expiration date of 180 days from 2026-08-27 17:21:39Z"
+    },
+    "e95e3d10fb88d3a57071069df6d352868372fc09118f0857086a8be8b8fcbabc": {
+      "signature": "e95e3d10fb88d3a57071069df6d352868372fc09118f0857086a8be8b8fcbabc",
+      "alternativeSignatures": [
+        "aab750d41030370e2675da23eb8c4db56167e37a8a7b6e7673cff4595463bbf6",
+        "1071b530f71905493a383912565b3ffe1743bcb477a526023f6d7c30d5cacabf",
+        "ea2ec5307dcbb71b3b87161bd02148dd8be8e59290446aa6bbdee83d9c7c1fd1"
+      ],
+      "target": "src/DurableEngine/Models/OrchestrationContext.cs",
+      "line": 85,
+      "uriBaseId": "file:///D:/a/_work/1/s/",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "roslynanalyzers",
+      "ruleId": "CA2327",
+      "createdDate": "2026-08-27 17:20:25Z",
+      "expirationDate": "2027-02-13 17:21:39Z",
+      "justification": "This error is baselined with an expiration date of 180 days from 2026-08-27 17:21:39Z"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Regenerates the 1ES Pipeline Templates baselines against `main` after #117.

The refreshed baseline contains only the two findings present in the current Guardian SARIF:
- CA2326 in `src/DurableEngine/Models/OrchestrationContext.cs:81`
- CA2327 in `src/DurableEngine/Models/OrchestrationContext.cs:85`

The stale CA2326/CA2327 entries for `SetFunctionInvocationContextCommand.cs` from the closed #118 are absent.

## Source and validation

- [1ES PT autobaseline build 300692](https://dev.azure.com/azfunc/3f99e810-c336-441f-8892-84983093ad7f/_build/results?buildId=300692) ran successfully against `bb42e2a` with the `1ES.PT.AutoBaseline` tag.
- Baseline signature IDs exactly match the hydrated `.gdnbaselines` artifact from build 300692.
- Current entries and expiration metadata match MerlinBot's regenerated publication.
- `dotnet build .\src\DurableSDK.sln --configuration Release --no-restore` succeeds with no warnings or errors.